### PR TITLE
Sidebar plugin working with carousel

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -8,7 +8,7 @@ integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+
 {% block book_sidebar %}
   {{ super() }}
   <div class="sidebar-addition">
-    {% if config.pluginsConfig['sidebar-ads'] %}  
+    {% if config.pluginsConfig['sidebar-ads'].ads %}  
     <div id="carouselAd" class="carousel slide" data-bs-ride="carousel">
       <div class="carousel-indicators">
         <button type="button" data-bs-target="#carouselAd" data-bs-slide-to="0" class="active" aria-current="true" ></button>
@@ -17,25 +17,8 @@ integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+
         <button type="button" data-bs-target="#carouselAd" data-bs-slide-to="{{ i }}"></button>
         {% endfor %}
       </div>
-      <div class="carousel-inner">     
-        <div class="carousel-item active">
-          {% if config.pluginsConfig['sidebar-ads'].patreon.url %}
-          <a href="{{ config.pluginsConfig['sidebar-ads'].patreon.url }}" target="_blank">
-          {% endif %} 
-          <img src="{{ config.pluginsConfig['sidebar-ads'].patreon.imageUrl }}">
-          {% if config.pluginsConfig['sidebar-ads'].patreon.url %}
-          </a> {% endif %}
-          {% if config.pluginsConfig['sidebar-ads'].patreon.description %}
-            <p>{{ config.pluginsConfig['sidebar-ads'].patreon.description }}</p>
-          {% endif %}
-          {% if config.pluginsConfig['sidebar-ads'].patreon.btnText %}
-            <a href="{{ config.pluginsConfig['sidebar-ads'].patreon.url }}" class="btn" target="_blank">
-            {{ config.pluginsConfig['sidebar-ads'].patreon.btnText }}
-            </a>
-          {% endif %}
-        </div>  
-        {% if config.pluginsConfig['sidebar-ads.sponsors-ads'] %}
-        {% for ad in config.pluginsConfig['sidebar-ads.sponsor-ads'] %}
+      <div class="carousel-inner">
+        {% for ad in config.pluginsConfig['sidebar-ads'].ads %}
         <div class="carousel-item">
           {% if ad.url %}
             <a href="{{ ad.url }}" target="_blank">
@@ -54,7 +37,6 @@ integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+
           {% endif %} 
         </div>
         {% endfor %}
-        {% endif %}
       </div>
       <button class="carousel-control-prev" type="button" data-bs-target="#carouselAd" data-bs-slide="prev">
         <span class="carousel-control-prev-icon" aria-hidden="true"></span>
@@ -67,13 +49,6 @@ integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+
     </div>
     {% endif %}
   </div>
-
-  <script>
-    var array = new Array();
-    for (i = 1; i <= config.pluginsConfig['sidebar-ads.sponsor-ads'].length; i++){
-      array[i]
-    }
-  </script>
 
 {% endblock %}
 

--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,51 +1,40 @@
 {% extends template.self %}
 
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" 
-rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" 
-integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+{% block head %} {{ super() }}
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
+{% endblock %}
 
 {% block book_sidebar %}
   {{ super() }}
   <div class="sidebar-addition">
     {% if config.pluginsConfig['sidebar-ads'].ads %}  
-    <div id="carouselAd" class="carousel slide" data-bs-ride="carousel">
-      <div class="carousel-indicators">
-        <button type="button" data-bs-target="#carouselAd" data-bs-slide-to="0" class="active" aria-current="true" ></button>
-        <!-- for loop to use indexes as slide numbers-->  
-        {% for i in array %}
-        <button type="button" data-bs-target="#carouselAd" data-bs-slide-to="{{ i }}"></button>
-        {% endfor %}
-      </div>
+    <div id="carouselAd" class="carousel carousel-dark slide" data-bs-ride="carousel">
       <div class="carousel-inner">
+        {% set i = true %}
         {% for ad in config.pluginsConfig['sidebar-ads'].ads %}
-        <div class="carousel-item">
-          {% if ad.url %}
-            <a href="{{ ad.url }}" target="_blank">
-          {% endif %}
+        <div class="carousel-item {% if i %} active{% endif %}">
             <img src="{{ ad.imageUrl }}">
-          {% if ad.url %}
-            </a>
-          {% endif %}
           {% if ad.description %}
-          <p>{{ ad.description }}</p>
+            <p>{{ ad.description }}</p>
           {% endif %}
           {% if ad.btnText %}
-          <a href="{{ ad.url }}" class="btn" target="_blank">
-            {{ ad.btnText }}
-          </a>
+            <a href="{{ ad.url }}" class="btn" target="_blank">
+              {{ ad.btnText }}
+            </a>
           {% endif %} 
         </div>
+        {% set i=false %}
         {% endfor %}
+        <button class="carousel-control-prev" type="button" data-bs-target="#carouselAd" data-bs-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">Previous</span>
+        </button>
+        <button class="carousel-control-next" type="button" data-bs-target="#carouselAd" data-bs-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">Next</span>
+        </button>
       </div>
-      <button class="carousel-control-prev" type="button" data-bs-target="#carouselAd" data-bs-slide="prev">
-        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-        <span class="visually-hidden">Previous</span>
-      </button>
-      <button class="carousel-control-next" type="button" data-bs-target="#carouselAd" data-bs-slide="next">
-        <span class="carousel-control-next-icon" aria-hidden="true"></span>
-        <span class="visually-hidden">Next</span>
-      </button>
     </div>
     {% endif %}
   </div>

--- a/assets/sidebar-ads.css
+++ b/assets/sidebar-ads.css
@@ -1,26 +1,31 @@
 .book-summary ul.summary {
   overflow-y: scroll;
-  height: calc(100% - 196px);
+  height: calc(100% - 220px);
   position: absolute;
   width: 300px;
+  font-size: 14px;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .sidebar-addition {
-  position:fixed;
+  position: fixed;
   height: 150px;
   width: 300px;
   left: 0;
-  bottom: 0;
+  bottom: 15px;
   background: #fafafa;
   border-top: 1px solid rgba(0,0,0,.07);
   border-right: 1px solid rgba(0,0,0,.07);
   text-align: center;
   display: none;
+  font-size: 12px;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .sidebar-addition img {
-  height: 90%;
-  margin: 2.5%;
+  max-height: 130px;
+  max-width: 180px;
+  margin: 5px;
   float: left;
 }
 
@@ -31,11 +36,14 @@
 }
 
 .sidebar-addition .btn {
+  font-size: 12px;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
   background: rgba(0,0,0,.07);
   color: rgba(0,0,0,0.4);
   padding: 5px 10px;
   border-radius: 4px;
-  margin-top: 5px;
+  margin-bottom: 5px;
+  width: 80px;
 }
 
 .with-summary .sidebar-addition {


### PR DESCRIPTION
The carousel with multiple ads should now be working.

Important note: this is using bootstrap 5, Django Girls tutorial is now using bootstrap 3. I already had to update some styling on the sidebar so I am not entirely sure this is the best idea to even use this plugin before updating the whole tutorial to use new bootstrap, but I know it was a bit urgent for you @amakarudze so here it is. As much as I could make it work.

It needs more styling in order to look nicely (e.g. the weird button with text outside of the button) but the JS part is working.

Configuration in the book:
```
        "sidebar-ads": {
            "ads": [
                {
                    "imageUrl": "https://djangogirls.org/static/img/global/donate/lagos.jpg",
                    "url": "https://www.patreon.com/djangogirls",
                    "description": "💖 Support our work and donate to our project! ✨",
                    "btnText": "Donate now!"
                },
                {
                    "imageUrl": "https://i.imgur.com/K3HPXzm.png",
                    "url": "http://google.com/",
                    "description": "text",
                    "btnText": "Buy me again!"
                }
            ]
        },
```

First ad will be active as default.

This is how it looks when it works:

https://user-images.githubusercontent.com/182546/227056355-fada2866-b787-4e1f-9ccd-a9ea76c2cc88.mov

